### PR TITLE
Use root instead of selector to select container

### DIFF
--- a/modules/node_modules/@oncojs/lolliplot/index.js
+++ b/modules/node_modules/@oncojs/lolliplot/index.js
@@ -102,7 +102,7 @@ let proteinLolliplot: TProteinLolliplot = ({
   // Main Chart
 
   let svg = d3
-    .select(selector)
+    .select(root)
     .append(`svg`)
     .attrs({
       class: `chart`,


### PR DESCRIPTION
root was created but left unused