### PR TITLE
Use attribute selector instead of #[id] selector

### DIFF
--- a/modules/node_modules/@oncojs/lolliplot/stats.js
+++ b/modules/node_modules/@oncojs/lolliplot/stats.js
@@ -128,7 +128,7 @@ let setupStats: TSetupStats = ({
         let checked = d3.event.target.dataset.checked === `true`
         let { consequenceFilters } = store.getState()
 
-        d3.select(`#toggle-consequence-${type}`)
+        d3.select(`[id="toggle-consequence-${type}"]`)
           .html(checked ? `✓` : `&nbsp;`)
 
         store.update({ consequenceFilters: checked


### PR DESCRIPTION
Apparently we have a consequence of `W161*`, which results in an invalid selector