### PR TITLE
Remove data from dom, save references to DOM nodes

### DIFF
--- a/modules/node_modules/@oncojs/lolliplot/animator.js
+++ b/modules/node_modules/@oncojs/lolliplot/animator.js
@@ -24,6 +24,8 @@ type TAnimatorArgs = {
   consequences: Object,
   impacts: Object,
   consequenceColors: Object,
+  impactsCheckboxContainers: Object,
+  consequencesCheckboxContainers: Object,
 }
 type TAnimator = (args: TAnimatorArgs) => Function
 let animator: TAnimator = ({
@@ -43,6 +45,8 @@ let animator: TAnimator = ({
   consequences,
   impacts,
   consequenceColors,
+  impactsCheckboxContainers,
+  consequencesCheckboxContainers,
 }) => {
 
   let draw = () => {
@@ -174,6 +178,8 @@ let animator: TAnimator = ({
       mutationChartCircles,
       height,
       xAxisOffset,
+      impactsCheckboxContainers,
+      consequencesCheckboxContainers,
     })
 
     if (store.getState().animating) window.requestAnimationFrame(draw)

--- a/modules/node_modules/@oncojs/lolliplot/index.js
+++ b/modules/node_modules/@oncojs/lolliplot/index.js
@@ -269,6 +269,23 @@ let proteinLolliplot: TProteinLolliplot = ({
       'pointer-events': `none`,
     })
 
+  let {impactsCheckboxContainers, consequencesCheckboxContainers} = setupStats({
+    consequenceColors,
+    data,
+    store,
+    selector,
+    hideStats,
+    statsBoxWidth,
+    width,
+    selectedMutationClass,
+    consequences,
+    impacts,
+    mutationChartLines,
+    mutationChartCircles,
+    height,
+    xAxisOffset,
+  })
+
   let draw = animator({
     store,
     data,
@@ -286,23 +303,8 @@ let proteinLolliplot: TProteinLolliplot = ({
     consequences,
     impacts,
     consequenceColors,
-  })
-
-  setupStats({
-    consequenceColors,
-    data,
-    store,
-    selector,
-    hideStats,
-    statsBoxWidth,
-    width,
-    selectedMutationClass,
-    consequences,
-    impacts,
-    mutationChartLines,
-    mutationChartCircles,
-    height,
-    xAxisOffset,
+    impactsCheckboxContainers,
+    consequencesCheckboxContainers,
   })
 
   let reset = () => {
@@ -324,6 +326,8 @@ let proteinLolliplot: TProteinLolliplot = ({
       xAxisOffset,
       mutationChartLines,
       mutationChartCircles,
+      impactsCheckboxContainers,
+      consequencesCheckboxContainers,
     })
 
     updateMutations({ checked: true, data, mutationClass: null, type: null })

--- a/modules/node_modules/@oncojs/lolliplot/stats.js
+++ b/modules/node_modules/@oncojs/lolliplot/stats.js
@@ -14,6 +14,26 @@ let impactsColors = {
   default: `rgb(135, 145, 150)`,
 }
 
+type TRenderCheckboxItemArgs = {
+  colors: Object,
+  type: String,
+  dataSource: Object,
+}
+type TRenderCheckboxItem =  (args: TRenderCheckboxItemArgs) => string
+function renderCheckboxItem({
+  colors,
+  type,
+  dataSource,
+}) : TRenderCheckboxItem {
+  return `
+    <span class="toggle-checkbox" data-checked="true" style="color: ${colors[type] || colors.default}; text-align: center; border: 2px solid ${colors[type] || colors.default}; display: inline-block; width: 23px; cursor: pointer; margin-right: 6px;">✓</span>
+    <span>${_.startCase(type)}:</span>
+    <span style="margin: 0 10px 0 auto;" class="counts">
+      <b>${dataSource[type].length}</b> / <b>${dataSource[type].length}</b>
+    </span>
+  `
+}
+
 type TSetupStatsArgs = {
   consequenceColors: Object,
   data: Object,
@@ -30,7 +50,7 @@ type TSetupStatsArgs = {
   height: number,
   xAxisOffset: number,
 }
-type TSetupStats = (args: TSetupStatsArgs) => void
+type TSetupStats = (args: TSetupStatsArgs) => Object
 let setupStats: TSetupStats = ({
   consequenceColors,
   data,
@@ -101,25 +121,21 @@ let setupStats: TSetupStats = ({
     .style(`margin-top`, `6px`)
     .style(`font-size`, `14px`)
 
-  Object.keys(consequences).map(type => {
+ let consequencesCheckboxContainers = _.mapValues(consequences, (item, type) => (
     consequencesContainer
       .append(`div`)
-      .html(`
-        <span id="toggle-consequence-${type}" data-checked="true" style="color: ${consequenceColors[type]}; text-align: center; border: 2px solid ${consequenceColors[type]}; display: inline-block; width: 23px; cursor: pointer; margin-right: 6px;">✓</span>
-        <span>${_.startCase(type)}:</span>
-        <span style="margin: 0 10px 0 auto;" class="consquence-counts-${type}">
-          <b>${consequences[type].length}</b> / <b>${consequences[type].length}</b>
-        </span>
-      `)
+      .html(renderCheckboxItem({
+        colors: consequenceColors,
+        type,
+        dataSource: consequences,
+      }))
       .style(`margin-top`, `6px`)
       .style(`font-size`, `14px`)
       .style(`display`, `flex`)
       .style(`align-items`, `center`)
-      .on(`click`, () => {
+      .on(`click`, function () {
         // Bail if not the checkbox above
-        if (!d3.event.target.id.includes(`toggle-consequence`)) return
-
-        let type = d3.event.target.id.split(`-`).pop()
+        if (!Array.from(d3.event.target.classList).includes(`toggle-checkbox`)) return
 
         d3.event.target.dataset.checked = d3.event.target.dataset.checked === `true`
           ? `false`
@@ -128,7 +144,7 @@ let setupStats: TSetupStats = ({
         let checked = d3.event.target.dataset.checked === `true`
         let { consequenceFilters } = store.getState()
 
-        d3.select(`#toggle-consequence-${type}`)
+        d3.select(this).select(`.toggle-checkbox`)
           .html(checked ? `✓` : `&nbsp;`)
 
         store.update({ consequenceFilters: checked
@@ -146,11 +162,13 @@ let setupStats: TSetupStats = ({
           mutationChartCircles,
           height,
           xAxisOffset,
+          impactsCheckboxContainers,
+          consequencesCheckboxContainers,
         })
 
         updateMutations({ checked, mutationClass: `consequence`, type, data })
       })
-  })
+ ))
 
   let impactsContainer = stats
     .append(`span`)
@@ -160,25 +178,21 @@ let setupStats: TSetupStats = ({
     .style(`margin-top`, `6px`)
     .style(`font-size`, `14px`)
 
-  Object.keys(impacts).map(type => {
+  let impactsCheckboxContainers = _.mapValues(impacts, (item, type) => (
     impactsContainer
       .append(`div`)
-      .html(`
-        <span id="toggle-impacts-${type}" data-checked="true" style="color: ${impactsColors[type] || impactsColors.default}; text-align: center; border: 2px solid ${impactsColors[type] || impactsColors.default}; display: inline-block; width: 23px; cursor: pointer; margin-right: 6px;">✓</span>
-        <span>${_.startCase(type)}:</span>
-        <span style="margin: 0 10px 0 auto;" class="impacts-counts-${type}">
-          <b>${impacts[type].length}</b> / <b>${impacts[type].length}</b>
-        </span>
-      `)
+      .html(renderCheckboxItem({
+        colors: impactsColors,
+        type,
+        dataSource: impacts,
+      }))
       .style(`margin-top`, `6px`)
       .style(`font-size`, `14px`)
       .style(`display`, `flex`)
       .style(`align-items`, `center`)
-      .on(`click`, () => {
+      .on(`click`, function () {
         // Bail if not the checkbox above
-        if (!d3.event.target.id.includes(`toggle-impacts`)) return
-
-        let type = d3.event.target.id.split(`-`).pop()
+        if (!Array.from(d3.event.target.classList).includes(`toggle-checkbox`)) return
 
         d3.event.target.dataset.checked = d3.event.target.dataset.checked === `true`
           ? `false`
@@ -187,7 +201,7 @@ let setupStats: TSetupStats = ({
         let checked = d3.event.target.dataset.checked === `true`
         let { impactFilters } = store.getState()
 
-        d3.select(`#toggle-impacts-${type}`)
+        d3.select(this).select(`.toggle-checkbox`)
           .html(checked ? `✓` : `&nbsp;`)
 
         store.update({ impactFilters: checked
@@ -205,11 +219,18 @@ let setupStats: TSetupStats = ({
           mutationChartCircles,
           height,
           xAxisOffset,
+          impactsCheckboxContainers,
+          consequencesCheckboxContainers,
         })
 
         updateMutations({ checked, mutationClass: `impact`, type, data })
       })
-  })
+  ))
+
+  return {
+    consequencesCheckboxContainers,
+    impactsCheckboxContainers,
+  }
 }
 
 type TUpdateStatsArgs = {
@@ -234,6 +255,8 @@ let updateStats: TUpdateStats = ({
   mutationChartCircles,
   height,
   xAxisOffset,
+  impactsCheckboxContainers,
+  consequencesCheckboxContainers,
 }) => {
   let { min, max, consequenceFilters, impactFilters, animating } = store.getState()
 
@@ -243,49 +266,21 @@ let updateStats: TUpdateStats = ({
     !impactFilters.includes(d.impact)
   )
 
-  let visibleConsequences = groupByType(`consequence`, visibleMutations)
-  let visibleImpacts = groupByType(`impact`, visibleMutations)
-
-  Object.keys(consequences).map(type => {
-    if (!visibleConsequences[type]) {
-      d3.select(`.consquence-counts-${type}`)
-        .html(`<b>0</b> / <b>${consequences[type].length}</b> `)
-    } else {
-      d3.select(`#toggle-consequence-${type}`)
-        .attr(`data-checked`, `true`)
-        .html(`✓`)
-    }
+  let visibleMutationCounts = {
+    impacts: _.countBy(visibleMutations, `impact`),
+    consequences: _.countBy(visibleMutations, `consequence`),
+  }
+  _.forEach(consequencesCheckboxContainers, (container, type) => {
+    container.select(`.counts`)
+        .html(`<b>${visibleMutationCounts.consequences[type] || 0}</b> / <b>${consequences[type].length}</b>`)
   })
-
-  Object.keys(impacts).map(type => {
-    if (!visibleImpacts[type]) {
-      d3.select(`.impacts-counts-${type}`)
-        .html(`<b>0</b> / <b>${impacts[type].length}</b>`)
-    } else {
-      d3.select(`#toggle-impacts-${type}`)
-        .attr(`data-checked`, `true`)
-        .html(`✓`)
-    }
+  _.forEach(impactsCheckboxContainers, (container, type) => {
+    container.select(`.counts`)
+        .html(`<b>${visibleMutationCounts.impacts[type] || 0}</b> / <b>${impacts[type].length}</b>`)
   })
 
   d3.select(`.mutation-count`)
     .html(`Viewing <b>${visibleMutations.length}</b> / <b>${data.mutations.length}</b> Mutations`)
-
-  Object
-    .keys(visibleConsequences)
-    .filter(type => !consequenceFilters.includes(type))
-    .map(type => {
-      d3.select(`.consquence-counts-${type}`)
-        .html(`<b>${visibleConsequences[type].length}</b> / <b>${consequences[type].length}</b>`)
-    })
-
-  Object
-    .keys(visibleImpacts)
-    .filter(type => !impactFilters.includes(type))
-    .map(type => {
-      d3.select(`.impacts-counts-${type}`)
-        .html(`<b>${visibleImpacts[type].length}</b> / <b>${impacts[type].length}</b>`)
-      })
 
   if (!animating) {
     animateScaleY({


### PR DESCRIPTION
Passing something from stat's `setupStats` to `updateStats` required changing things a few more places than I was expecting (I don't think I should have to touch animator.js and index.js but can't see a way around that currently, since the `draw` in `animator.js` needs to call `updateStats`)

Also concerned that having to add cached DOM elements to the updates object would be kind of messy if scaled up  

What do you think about in addition to #21, also internally decoupling the stats from the chart?

This PR also happens to fix #14