### PR TITLE
[PRTL-2511] remove clipping path from backbone

### DIFF
--- a/modules/node_modules/@oncojs/react-lolliplot/BackboneNode.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/BackboneNode.js
@@ -18,9 +18,9 @@ let BackboneNode = (
     domainWidth = 500,
     yAxisOffset = 45,
     proteinDb = `pfam`,
-    onProteinClick = () => {},
-    onProteinMouseover = () => {},
-    onProteinMouseout = () => {},
+    onProteinClick = () => { },
+    onProteinMouseover = () => { },
+    onProteinMouseout = () => { },
     min,
     max,
     proteinMouseover,
@@ -42,6 +42,8 @@ let BackboneNode = (
   let uniqueSelector = uuid()
   let xAxisLength = width - yAxisOffset
   let scale = xAxisLength / domainWidth
+
+  console.log('hello world')
 
   // Main Chart
 
@@ -82,7 +84,6 @@ let BackboneNode = (
     .enter()
     .append(`rect`)
     .attrs({
-      "clip-path": `url(#${uniqueSelector}-chart-clip)`,
       class: d => `range-${d.id}-${d.start}-${d.end}`,
       x: d => Math.max(yAxisOffset, scaleLinear(d.start)) + halfPixel,
       y: Math.round(height / 2) - 7,
@@ -110,19 +111,24 @@ let BackboneNode = (
         ${proteinMouseover === d.id ? 65 : 60}%)
       `,
       strokeWidth: 1,
-      cursor: `pointer`,
     })
+    .style(`cursor`, `pointer`)
+    .style('z-index', '9999')
+    .style('background', 'black')
     .on(`click`, d => {
+      console.log('click')
       if (onProteinClick) {
         onProteinClick(d)
       }
     })
     .on(`mouseover`, d => {
+      console.log('mouseover')
       if (onProteinMouseover) {
         onProteinMouseover(d, d3.event)
       }
     })
     .on(`mouseout`, d => {
+      console.log('mouseout')
       if (onProteinMouseout) {
         onProteinMouseout(d, d3.event)
       }

--- a/modules/node_modules/@oncojs/react-lolliplot/BackboneNode.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/BackboneNode.js
@@ -18,9 +18,9 @@ let BackboneNode = (
     domainWidth = 500,
     yAxisOffset = 45,
     proteinDb = `pfam`,
-    onProteinClick = () => { },
-    onProteinMouseover = () => { },
-    onProteinMouseout = () => { },
+    onProteinClick = () => {},
+    onProteinMouseover = () => {},
+    onProteinMouseout = () => {},
     min,
     max,
     proteinMouseover,
@@ -42,8 +42,6 @@ let BackboneNode = (
   let uniqueSelector = uuid()
   let xAxisLength = width - yAxisOffset
   let scale = xAxisLength / domainWidth
-
-  console.log('hello world')
 
   // Main Chart
 
@@ -113,22 +111,17 @@ let BackboneNode = (
       strokeWidth: 1,
     })
     .style(`cursor`, `pointer`)
-    .style('z-index', '9999')
-    .style('background', 'black')
     .on(`click`, d => {
-      console.log('click')
       if (onProteinClick) {
         onProteinClick(d)
       }
     })
     .on(`mouseover`, d => {
-      console.log('mouseover')
       if (onProteinMouseover) {
         onProteinMouseover(d, d3.event)
       }
     })
     .on(`mouseout`, d => {
-      console.log('mouseout')
       if (onProteinMouseout) {
         onProteinMouseout(d, d3.event)
       }

--- a/modules/node_modules/@oncojs/react-lolliplot/package.json
+++ b/modules/node_modules/@oncojs/react-lolliplot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oncojs/react-lolliplot",
-  "version": "0.11.1",
+  "version": "0.11.4",
   "description": "A protein viewer built with d3 (React Component)",
   "browser": true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lolliplot",
-  "version": "0.11.2",
+  "version": "0.0.0",
   "description": "A protein viewer built with d3",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
- make `cursor pointer` a CSS property instead of an attribute, for Firefox compatibility
- remove `clip-path` because it was preventing interaction in Firefox

note: if testing locally, run in node 8, and install xcode