### PR TITLE
[PRTL-2967] Lolliplot X-axis position

### DIFF
--- a/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
@@ -34,13 +34,10 @@ let Lolliplot = ({
 } = {}) => {
   invariant(d3, `You must pass in the d3 library, either v3 || v4`)
 
-  // definitely need floor & round here.
   min = Math.floor(min)
   max = Math.round(max)
-  // console.log(`min`, min, `max`, max)
 
   let length = (max - min) / numXTicks
-  let olength = domainWidth / numXTicks
 
   const uniqueXTicks = uniq(
     range(numXTicks - 1)
@@ -57,15 +54,7 @@ let Lolliplot = ({
   min = uniqueXTicks[0] - xTickInt
   max = uniqueXTicks[numUniqueXTicks - 1]
 
-  // console.log(`new min`, min, `new max`, max, `xTickInt`, xTickInt)
-
-  // console.log(data)
-
-  console.log(`uniqueXTicks`, uniqueXTicks)
-  // console.log(`numUniqueXTicks`, numUniqueXTicks)
-
   length = (max - min) / numUniqueXTicks
-  olength = domainWidth / numUniqueXTicks
 
   d3.selection.prototype.attrs = attrs
   d3.scaleOrdinal = d3.scaleOrdinal || d3.scale.ordinal
@@ -95,7 +84,6 @@ let Lolliplot = ({
 
   let scaleLinearY = d3
     .scaleLinear()
-    // what does numXTicks do here
     .domain([-highestValue / numXTicks, highestValue])
     .range([height - xAxisOffset, 15])
 
@@ -174,15 +162,11 @@ let Lolliplot = ({
     .attrs({
       class: d => `mutation-line-${d.id}`,
       'clip-path': `url(#${uniqueSelector}-chart-clip)`,
-      x1: d => {  
-        // console.log(d.x)
-        return scaleLinear(d.x)
-      },
+      x1: d => scaleLinear(d.x),
       y1: height - xAxisOffset,
       x2: d => scaleLinear(d.x),
       y2: d => scaleLinearY(d.y),
-      // stroke: `rgba(0, 0, 0, 0.2)`,
-      stroke: `magenta`,
+      stroke: `rgba(0, 0, 0, 0.2)`,
     })
 
   svg
@@ -307,6 +291,8 @@ let Lolliplot = ({
 
   svg.append(`g`).attr(`class`, `xTicks`)
 
+  let olength = domainWidth / numUniqueXTicks
+
   d3Root
     .select(`.xTicks`)
     .append(`g`)
@@ -324,7 +310,6 @@ let Lolliplot = ({
       'pointer-events': `none`,
     })
 
-  // unique ticks?
   for (let i = 1; i < numUniqueXTicks; i++) {
     let length = domainWidth / numUniqueXTicks
 

--- a/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
@@ -11,8 +11,6 @@ import theme from './theme'
 
 /*----------------------------------------------------------------------------*/
 
-const useRounding = false
-
 let Lolliplot = ({
   d3,
   data,
@@ -75,8 +73,6 @@ let Lolliplot = ({
     .scaleLinear()
     .domain([min, max])
     .range([yAxisOffset, width])
-
-    console.log(yAxisOffset, width)
 
   let maxY = Math.max(...visibleData.map(d => d.y))
 
@@ -153,8 +149,6 @@ let Lolliplot = ({
       stroke: theme.black,
     })
 
-  const visiblePopsXPositions = {}
-
   svg
     .append(`g`)
     .selectAll(`line`)
@@ -166,22 +160,16 @@ let Lolliplot = ({
       'clip-path': `url(#${uniqueSelector}-chart-clip)`,
       x1: d => {
         let x1 = scaleLinear(d.x)
-        if (d.x >= min && d.x <= max) {
-          visiblePopsXPositions[d.x] = x1
-        }
         return x1
       },
       y1: height - xAxisOffset,
       x2: d => {
         let x2 = scaleLinear(d.x)
-        x2 = useRounding ? Math.round(x2) : x2
         return x2
       },
       y2: d => scaleLinearY(d.y),
       stroke: `rgba(0, 0, 0, 0.2)`,
     })
-  
-  console.log(`visiblePopsXPositions`, visiblePopsXPositions)
 
   svg
     .append(`g`)
@@ -307,8 +295,6 @@ let Lolliplot = ({
 
   let olength = domainWidth / numUniqueXTicks
 
-  olength = useRounding ? Math.round(olength) : olength
-
   let tickXPositions = {}
 
   d3Root
@@ -323,7 +309,6 @@ let Lolliplot = ({
       class: i => `xTick-text-${i}`,
       x: i => {
         let tickX = olength * i * scale + yAxisOffset
-        tickX = useRounding ? Math.round(tickX) : tickX
         tickXPositions[uniqueXTicks[i - 1]] = tickX
         return tickX
       },
@@ -333,18 +318,16 @@ let Lolliplot = ({
       'pointer-events': `none`,
     })
 
-  // yAxisOffset is 45
-  console.log(`x ticks`, olength, tickXPositions)
-
   for (let i = 1; i < numUniqueXTicks; i++) {
+    const x = olength * i * scale + yAxisOffset
     d3Root
       .select(`.xTicks`)
       .append(`line`)
       .attrs({
         class: `xTick-line-${i}`,
-        x1: olength * i * scale + yAxisOffset,
+        x1: x,
         y1: height - xAxisOffset,
-        x2: olength * i * scale + yAxisOffset,
+        x2: x,
         y2: height - xAxisOffset + 10,
         stroke: theme.black,
         'pointer-events': `none`,

--- a/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
@@ -11,6 +11,8 @@ import theme from './theme'
 
 /*----------------------------------------------------------------------------*/
 
+const useRounding = false
+
 let Lolliplot = ({
   d3,
   data,
@@ -34,54 +36,53 @@ let Lolliplot = ({
 } = {}) => {
   invariant(d3, `You must pass in the d3 library, either v3 || v4`)
 
-  min = Math.floor(min)
-  max = Math.round(max)
-
-  let length = (max - min) / numXTicks
+  const xTickInt = (max - min) / numXTicks
 
   const uniqueXTicks = uniq(
     range(numXTicks - 1)
       .map(x => x + 1)
-      .map(i => Math.round(length * i + min))
+      .map(i => Math.round(xTickInt * i + min))
   )
 
   const numUniqueXTicks = uniqueXTicks.length
 
-  const xTickInt = numUniqueXTicks.length === 1
+  const xTickDistance = numUniqueXTicks.length === 1
     ? 1
     : uniqueXTicks[1] - uniqueXTicks[0]
   
   // min & max are invisible ticks on the far left and right
-  min = uniqueXTicks[0] - xTickInt
+  min = uniqueXTicks[0] - xTickDistance
   max = uniqueXTicks[numUniqueXTicks - 1]
 
   d3.selection.prototype.attrs = attrs
   d3.scaleOrdinal = d3.scaleOrdinal || d3.scale.ordinal
   d3.scaleLinear = d3.scaleLinear || d3.scale.linear
 
-  let root = ReactFauxDOM.createElement(`div`)
+  const root = ReactFauxDOM.createElement(`div`)
 
   invariant(root, `Must provide an element or selector!`)
 
   width = width || root.clientWidth
   height = height || root.clientHeight
 
-  let uniqueSelector = uuid()
-  let xAxisLength = width - yAxisOffset
-  let scale = xAxisLength / domainWidth
+  const uniqueSelector = uuid()
+  const xAxisLength = width - yAxisOffset
+  const scale = xAxisLength / domainWidth
 
-  let visibleData = data.filter(d => d.x > min && d.x < max)
+  const visibleData = data.filter(d => d.x >= min && d.x <= max)
 
-  let scaleLinear = d3
+  const scaleLinear = d3
     .scaleLinear()
     .domain([min, max])
     .range([yAxisOffset, width])
+
+    console.log(yAxisOffset, width)
 
   let maxY = Math.max(...visibleData.map(d => d.y))
 
   let highestValue = Math.max(10, maxY)
 
-  let scaleLinearY = d3
+  const scaleLinearY = d3
     .scaleLinear()
     .domain([-highestValue / numXTicks, highestValue])
     .range([height - xAxisOffset, 15])
@@ -152,6 +153,8 @@ let Lolliplot = ({
       stroke: theme.black,
     })
 
+  const visiblePopsXPositions = {}
+
   svg
     .append(`g`)
     .selectAll(`line`)
@@ -161,12 +164,24 @@ let Lolliplot = ({
     .attrs({
       class: d => `mutation-line-${d.id}`,
       'clip-path': `url(#${uniqueSelector}-chart-clip)`,
-      x1: d => scaleLinear(d.x),
+      x1: d => {
+        let x1 = scaleLinear(d.x)
+        if (d.x >= min && d.x <= max) {
+          visiblePopsXPositions[d.x] = x1
+        }
+        return x1
+      },
       y1: height - xAxisOffset,
-      x2: d => scaleLinear(d.x),
+      x2: d => {
+        let x2 = scaleLinear(d.x)
+        x2 = useRounding ? Math.round(x2) : x2
+        return x2
+      },
       y2: d => scaleLinearY(d.y),
       stroke: `rgba(0, 0, 0, 0.2)`,
     })
+  
+  console.log(`visiblePopsXPositions`, visiblePopsXPositions)
 
   svg
     .append(`g`)
@@ -292,6 +307,10 @@ let Lolliplot = ({
 
   let olength = domainWidth / numUniqueXTicks
 
+  olength = useRounding ? Math.round(olength) : olength
+
+  let tickXPositions = {}
+
   d3Root
     .select(`.xTicks`)
     .append(`g`)
@@ -302,24 +321,30 @@ let Lolliplot = ({
     .text(i => uniqueXTicks[i - 1])
     .attrs({
       class: i => `xTick-text-${i}`,
-      x: i => olength * i * scale + yAxisOffset,
+      x: i => {
+        let tickX = olength * i * scale + yAxisOffset
+        tickX = useRounding ? Math.round(tickX) : tickX
+        tickXPositions[uniqueXTicks[i - 1]] = tickX
+        return tickX
+      },
       y: height - xAxisOffset + 20,
       'font-size': `11px`,
       'text-anchor': `middle`,
       'pointer-events': `none`,
     })
 
-  for (let i = 1; i < numUniqueXTicks; i++) {
-    let length = domainWidth / numUniqueXTicks
+  // yAxisOffset is 45
+  console.log(`x ticks`, olength, tickXPositions)
 
+  for (let i = 1; i < numUniqueXTicks; i++) {
     d3Root
       .select(`.xTicks`)
       .append(`line`)
       .attrs({
         class: `xTick-line-${i}`,
-        x1: length * i * scale + yAxisOffset,
+        x1: olength * i * scale + yAxisOffset,
         y1: height - xAxisOffset,
-        x2: length * i * scale + yAxisOffset,
+        x2: olength * i * scale + yAxisOffset,
         y2: height - xAxisOffset + 10,
         stroke: theme.black,
         'pointer-events': `none`,

--- a/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
@@ -50,7 +50,18 @@ let Lolliplot = ({
 
   const numUniqueXTicks = uniqueXTicks.length
 
-  // console.log(`uniqueXTicks`, uniqueXTicks)
+  const xTickInt = numUniqueXTicks.length === 1
+    ? 1
+    : uniqueXTicks[1] - uniqueXTicks[0]
+  
+  min = uniqueXTicks[0] - xTickInt
+  max = uniqueXTicks[numUniqueXTicks - 1]
+
+  // console.log(`new min`, min, `new max`, max, `xTickInt`, xTickInt)
+
+  // console.log(data)
+
+  console.log(`uniqueXTicks`, uniqueXTicks)
   // console.log(`numUniqueXTicks`, numUniqueXTicks)
 
   length = (max - min) / numUniqueXTicks
@@ -76,7 +87,6 @@ let Lolliplot = ({
   let scaleLinear = d3
     .scaleLinear()
     .domain([min, max])
-    // min -1 maybe?
     .range([yAxisOffset, width])
 
   let maxY = Math.max(...visibleData.map(d => d.y))
@@ -164,7 +174,10 @@ let Lolliplot = ({
     .attrs({
       class: d => `mutation-line-${d.id}`,
       'clip-path': `url(#${uniqueSelector}-chart-clip)`,
-      x1: d => scaleLinear(d.x),
+      x1: d => {  
+        // console.log(d.x)
+        return scaleLinear(d.x)
+      },
       y1: height - xAxisOffset,
       x2: d => scaleLinear(d.x),
       y2: d => scaleLinearY(d.y),

--- a/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
@@ -34,10 +34,10 @@ let Lolliplot = ({
 } = {}) => {
   invariant(d3, `You must pass in the d3 library, either v3 || v4`)
 
-  // floor or round?
-  // min = Math.floor(min)
-  // max = Math.round(max)
-  console.log(min, max)
+  // definitely need floor & round here.
+  min = Math.floor(min)
+  max = Math.round(max)
+  // console.log(`min`, min, `max`, max)
 
   let length = (max - min) / numXTicks
   let olength = domainWidth / numXTicks
@@ -49,6 +49,9 @@ let Lolliplot = ({
   )
 
   const numUniqueXTicks = uniqueXTicks.length
+
+  // console.log(`uniqueXTicks`, uniqueXTicks)
+  // console.log(`numUniqueXTicks`, numUniqueXTicks)
 
   length = (max - min) / numUniqueXTicks
   olength = domainWidth / numUniqueXTicks
@@ -309,7 +312,7 @@ let Lolliplot = ({
     })
 
   // unique ticks?
-  for (let i = 1; i < numXTicks; i++) {
+  for (let i = 1; i < numUniqueXTicks; i++) {
     let length = domainWidth / numUniqueXTicks
 
     d3Root

--- a/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
@@ -51,6 +51,7 @@ let Lolliplot = ({
     ? 1
     : uniqueXTicks[1] - uniqueXTicks[0]
   
+  // min & max are invisible ticks on the far left and right
   min = uniqueXTicks[0] - xTickInt
   max = uniqueXTicks[numUniqueXTicks - 1]
 

--- a/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
@@ -268,7 +268,7 @@ let Lolliplot = ({
       class: i => `yTick-text-${i}`,
       x: yAxisOffset - 10,
       y: i => scaleLinearY(i) + 3,
-      'font-size': `10px`,
+      'font-size': `11px`,
       'text-anchor': `end`,
     })
 

--- a/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
@@ -34,6 +34,25 @@ let Lolliplot = ({
 } = {}) => {
   invariant(d3, `You must pass in the d3 library, either v3 || v4`)
 
+  // floor or round?
+  // min = Math.floor(min)
+  // max = Math.round(max)
+  console.log(min, max)
+
+  let length = (max - min) / numXTicks
+  let olength = domainWidth / numXTicks
+
+  const uniqueXTicks = uniq(
+    range(numXTicks - 1)
+      .map(x => x + 1)
+      .map(i => Math.round(length * i + min))
+  )
+
+  const numUniqueXTicks = uniqueXTicks.length
+
+  length = (max - min) / numUniqueXTicks
+  olength = domainWidth / numUniqueXTicks
+
   d3.selection.prototype.attrs = attrs
   d3.scaleOrdinal = d3.scaleOrdinal || d3.scale.ordinal
   d3.scaleLinear = d3.scaleLinear || d3.scale.linear
@@ -54,6 +73,7 @@ let Lolliplot = ({
   let scaleLinear = d3
     .scaleLinear()
     .domain([min, max])
+    // min -1 maybe?
     .range([yAxisOffset, width])
 
   let maxY = Math.max(...visibleData.map(d => d.y))
@@ -62,6 +82,7 @@ let Lolliplot = ({
 
   let scaleLinearY = d3
     .scaleLinear()
+    // what does numXTicks do here
     .domain([-highestValue / numXTicks, highestValue])
     .range([height - xAxisOffset, 15])
 
@@ -144,7 +165,8 @@ let Lolliplot = ({
       y1: height - xAxisOffset,
       x2: d => scaleLinear(d.x),
       y2: d => scaleLinearY(d.y),
-      stroke: `rgba(0, 0, 0, 0.2)`,
+      // stroke: `rgba(0, 0, 0, 0.2)`,
+      stroke: `magenta`,
     })
 
   svg
@@ -269,20 +291,6 @@ let Lolliplot = ({
 
   svg.append(`g`).attr(`class`, `xTicks`)
 
-  let length = (max - min) / numXTicks
-  let olength = domainWidth / numXTicks
-
-  const uniqueXTicks = uniq(
-    range(numXTicks - 1)
-      .map(x => x + 1)
-      .map(i => Math.round(length * i + min))
-  )
-  
-  const numUniqueXTicks = uniqueXTicks.length
-
-  length = (max - min) / numUniqueXTicks
-  olength = domainWidth / numUniqueXTicks
-
   d3Root
     .select(`.xTicks`)
     .append(`g`)
@@ -300,6 +308,7 @@ let Lolliplot = ({
       'pointer-events': `none`,
     })
 
+  // unique ticks?
   for (let i = 1; i < numXTicks; i++) {
     let length = domainWidth / numUniqueXTicks
 

--- a/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
@@ -55,8 +55,6 @@ let Lolliplot = ({
   min = uniqueXTicks[0] - xTickInt
   max = uniqueXTicks[numUniqueXTicks - 1]
 
-  length = (max - min) / numUniqueXTicks
-
   d3.selection.prototype.attrs = attrs
   d3.scaleOrdinal = d3.scaleOrdinal || d3.scale.ordinal
   d3.scaleLinear = d3.scaleLinear || d3.scale.linear

--- a/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/LolliplotNode.js
@@ -3,6 +3,7 @@
 import invariant from 'invariant'
 import ReactFauxDOM from 'react-faux-dom'
 import range from 'lodash.range'
+import uniq from 'lodash.uniq'
 import attrs from './utils/attrs'
 import { dim } from './utils/spatial'
 import uuid from './utils/uuid'
@@ -244,7 +245,7 @@ let Lolliplot = ({
       class: i => `yTick-text-${i}`,
       x: yAxisOffset - 10,
       y: i => scaleLinearY(i) + 3,
-      'font-size': `11px`,
+      'font-size': `10px`,
       'text-anchor': `end`,
     })
 
@@ -271,14 +272,25 @@ let Lolliplot = ({
   let length = (max - min) / numXTicks
   let olength = domainWidth / numXTicks
 
+  const uniqueXTicks = uniq(
+    range(numXTicks - 1)
+      .map(x => x + 1)
+      .map(i => Math.round(length * i + min))
+  )
+  
+  const numUniqueXTicks = uniqueXTicks.length
+
+  length = (max - min) / numUniqueXTicks
+  olength = domainWidth / numUniqueXTicks
+
   d3Root
     .select(`.xTicks`)
     .append(`g`)
     .selectAll(`text`)
-    .data(range(numXTicks - 1).map(x => x + 1))
+    .data(range(numUniqueXTicks - 1).map(x => x + 1))
     .enter()
     .append(`text`)
-    .text(i => Math.round(length * i + min))
+    .text(i => uniqueXTicks[i - 1])
     .attrs({
       class: i => `xTick-text-${i}`,
       x: i => olength * i * scale + yAxisOffset,
@@ -289,7 +301,7 @@ let Lolliplot = ({
     })
 
   for (let i = 1; i < numXTicks; i++) {
-    let length = domainWidth / numXTicks
+    let length = domainWidth / numUniqueXTicks
 
     d3Root
       .select(`.xTicks`)

--- a/modules/node_modules/@oncojs/react-lolliplot/utils/uuid.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/utils/uuid.js
@@ -1,5 +1,4 @@
 let uuid = a => a
   ? (a ^ Math.random() * 16 >> a / 4).toString(16)
   : ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, uuid)
-  
 export default uuid

--- a/modules/node_modules/@oncojs/react-lolliplot/utils/uuid.js
+++ b/modules/node_modules/@oncojs/react-lolliplot/utils/uuid.js
@@ -1,5 +1,5 @@
 let uuid = a => a
   ? (a ^ Math.random() * 16 >> a / 4).toString(16)
   : ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, uuid)
-
+  
 export default uuid

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lodash.countby": "^4.6.0",
     "lodash.range": "^3.2.0",
     "lodash.startcase": "^4.4.0",
+    "lodash.uniq": "4.5.0",
     "react": "^15.4.1",
     "react-faux-dom": "^3.0.1",
     "redux": "^3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3772,6 +3772,11 @@ lodash.toplainobject@^3.0.0:
     lodash._basecopy "^3.0.0"
     lodash.keysin "^3.0.0"
 
+lodash.uniq@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
+
 lodash.words@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.words/-/lodash.words-3.2.0.tgz#4e2a8649bc08745b17c695b1a3ce8fee596623b3"


### PR DESCRIPTION
make lollipops align correctly with X-axis ticks

they were using different scales of measurement before, and there were duplicate ticks. so instead, I made the ticks unique, made a scale based on those ticks, and applied that to the lollipops.